### PR TITLE
Update trandingdialog.cpp

### DIFF
--- a/src/qt/tradingdialog.cpp
+++ b/src/qt/tradingdialog.cpp
@@ -221,8 +221,8 @@ QString tradingDialog::BuyLUX(QString OrderType, double Quantity, double Rate){
     QString URL = "https://www.cryptopia.co.nz/api/SubmitTrade";
 
     QJsonObject stats_obj;
-    stats_obj["Market"] = "LUX/BTC";
-    stats_obj["Type"] = "Buy";
+    stats_obj["Market"] = QStringLiteral("LUX/BTC");
+    stats_obj["Type"] = QStringLiteral("Buy");
     stats_obj["Amount"] = Quantity;
     stats_obj["Rate"] = Rate;
 
@@ -240,8 +240,8 @@ QString tradingDialog::SellLUX(QString OrderType, double Quantity, double Rate){
     QString URL = "https://www.cryptopia.co.nz/api/SubmitTrade";
 
     QJsonObject stats_obj;
-    stats_obj["Market"] = "LUX/BTC";
-    stats_obj["Type"] = "Sell";
+    stats_obj["Market"] = QStringLiteral("LUX/BTC");
+    stats_obj["Type"] = QStringLiteral("Sell");
     stats_obj["Amount"] = Quantity;
     stats_obj["Rate"] = Rate;
 


### PR DESCRIPTION
Changed strings to QStringLiteral(string) according to https://stackoverflow.com/questions/21816908/qjsonvalue-is-private

Errors which occured before the change (Ubuntu 14.04):
/usr/include/qt5/QtCore/qjsonvalue.h:119:12: error: ‘QJsonValue::QJsonValue(const void*)’ is private
     inline QJsonValue(const void *) {}
qt/tradingdialog.cpp:224:25: error: within this context
     stats_obj["Market"] = "LUX/BTC";

qt/tradingdialog.cpp:225:23: error: within this context
     stats_obj["Type"] = "Buy";

qt/tradingdialog.cpp:243:25: error: within this context
     stats_obj["Market"] = "LUX/BTC";

qt/tradingdialog.cpp:244:23: error: within this context
     stats_obj["Type"] = "Sell";